### PR TITLE
fixes #4

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,7 @@ const embed1 = new EmbedBuilder()
       inline: true,
     }
   )
-  .setFooter("CSI-VIT");
+  .setFooter({ text: "CSI-VIT" });
 
 const embed2 = new EmbedBuilder()
   .setTitle("ForkThis Timeline")


### PR DESCRIPTION
Corrected syntax error of Pool Prize Embed (Issue #4) by passing string inside JSON object instead of passing only string in the `setFooter()` method.
